### PR TITLE
Provide Groovy shell context for version 6

### DIFF
--- a/resources/firefly.build.number
+++ b/resources/firefly.build.number
@@ -1,3 +1,3 @@
-version=1.1.0
-releasedate=20190402 1600
+version=1.1.1
+releasedate=20190405 1100
 description=https://github.com/neuland/firefly

--- a/src/de/neuland/firefly/changes/GroovyChange.java
+++ b/src/de/neuland/firefly/changes/GroovyChange.java
@@ -4,10 +4,14 @@ import de.hybris.platform.core.Registry;
 import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
 import org.apache.log4j.Logger;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -23,7 +27,8 @@ public class GroovyChange extends Change {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         Log4JPrintStream log4JPrintStream = new Log4JPrintStream(getChangeLogger(), new PrintStream(output));
         try {
-            Binding binding = new Binding(createShellContext(log4JPrintStream));
+            ApplicationContext applicationContext = Registry.getApplicationContext();
+            Binding binding = new Binding(createShellContext(applicationContext, log4JPrintStream));
             new GroovyShell(binding).evaluate(getChangeContent());
         } catch (Exception e) {
             throw new ChangeExecutionException(e, this);
@@ -37,10 +42,44 @@ public class GroovyChange extends Change {
         }
     }
 
-    private Map<String, Object> createShellContext(Log4JPrintStream output) {
+    public static Map<String, Object> createShellContext(ApplicationContext applicationContext,
+                                                         Log4JPrintStream output) {
         final Map<String, Object> shellContext = new HashMap<>();
-        shellContext.put("ctx", Registry.getApplicationContext());
+
+        // hybris 5
+        shellContext.put("ctx", applicationContext);
+        // hybris 6
+        shellContext.put("spring", applicationContext);
+        bindSpringBeans(applicationContext, shellContext);
+
+        // all versions
         shellContext.put("out", output);
+
         return shellContext;
+    }
+
+    private static void bindSpringBeans(ApplicationContext applicationContext, Map<String, Object> shellContext) {
+        GenericApplicationContext genericApplicationContext = (GenericApplicationContext) applicationContext;
+
+        for (String beanName : genericApplicationContext.getBeanDefinitionNames()) {
+            BeanDefinition beanDefinition = genericApplicationContext.getBeanDefinition(beanName);
+            if (beanDefinition.isAbstract() || beanName.contains(".")) {
+                continue;
+            }
+            String[] aliases = genericApplicationContext.getAliases(beanName);
+            try {
+                Object bean = applicationContext.getBean(beanName);
+                if (aliases.length > 0) {
+                    for (String alias : aliases) {
+                        shellContext.put(alias, bean);
+                    }
+                } else {
+                    shellContext.put(beanName, bean);
+                }
+            } catch (Exception e) {
+                LOG.warn(String.format("Failed to bind %s to Groovy script: %s",
+                    beanName, e.getMessage()));
+            }
+        }
     }
 }

--- a/src/de/neuland/firefly/utils/GroovyScriptRunner.java
+++ b/src/de/neuland/firefly/utils/GroovyScriptRunner.java
@@ -3,12 +3,14 @@ package de.neuland.firefly.utils;
 import de.hybris.platform.core.Registry;
 import de.hybris.platform.jdbcwrapper.JDBCConnectionPool;
 import de.neuland.firefly.changes.Change;
+import de.neuland.firefly.changes.GroovyChange;
 import de.neuland.firefly.changes.Log4JPrintStream;
 import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
 import groovy.sql.Sql;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayOutputStream;
@@ -64,11 +66,13 @@ public class GroovyScriptRunner {
     }
 
     private Map<String, Object> createShellContext(Log4JPrintStream output, Connection connection) {
-        final Map<String, Object> shellContext = new HashMap<>();
-        shellContext.put("ctx", Registry.getApplicationContext());
-        shellContext.put("out", output);
+        ApplicationContext applicationContext = Registry.getApplicationContext();
+
+        final Map<String, Object> shellContext = GroovyChange.createShellContext(applicationContext, output);
+
         shellContext.put("fireflyContext", fireflyContext);
         shellContext.put("sql", new Sql(connection));
+
         return shellContext;
     }
 

--- a/testsrc/de/neuland/firefly/changes/GroovyChangeTest.java
+++ b/testsrc/de/neuland/firefly/changes/GroovyChangeTest.java
@@ -1,0 +1,158 @@
+package de.neuland.firefly.changes;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.beans.MutablePropertyValues;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConstructorArgumentValues;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.isA;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GroovyChangeTest {
+    @Mock
+    private GenericApplicationContext applicationContext;
+    @Mock
+    private Log4JPrintStream out;
+
+    @Before
+    public void setUp() {
+        given(applicationContext.getBeanDefinitionNames()).willReturn(new String[0]);
+    }
+
+    @Test
+    public void shouldBindApplicationContextForVersionsUpTo5() {
+        // when
+        Map<String, Object> shellContext = GroovyChange.createShellContext(applicationContext, out);
+
+        // then
+        assertThat(shellContext).contains(entry("ctx", applicationContext));
+    }
+
+    @Test
+    public void shouldBindApplicationContextForVersions6() {
+        // when
+        Map<String, Object> shellContext = GroovyChange.createShellContext(applicationContext, out);
+
+        // then
+        assertThat(shellContext).contains(entry("spring", applicationContext));
+    }
+
+    @Test
+    public void shouldBindSpringBeans() {
+        // given
+        TestBean bean1 = prepareBean("bean1");
+        TestBean bean2 = prepareBean("bean2");
+        given(applicationContext.getBeanDefinitionNames()).willReturn(new String[]{
+            bean1.name(),
+            bean2.name()
+        });
+
+        // when
+        Map<String, Object> shellContext = GroovyChange.createShellContext(applicationContext, out);
+
+        // then
+        assertThat(shellContext).contains(
+            entry(bean1.name(), bean1),
+            entry(bean2.name(), bean2)
+        );
+    }
+
+    @Test
+    public void shouldNotBindAbstractSpringBeans() {
+        // given
+        TestBean bean = prepareBean("bean1");
+        TestBean abstractBean = prepareBean("abstractBean", true);
+        given(applicationContext.getBeanDefinitionNames()).willReturn(new String[]{
+            bean.name(),
+            abstractBean.name()
+        });
+
+        // when
+        Map<String, Object> shellContext = GroovyChange.createShellContext(applicationContext, out);
+
+        // then
+        assertThat(shellContext).doesNotContainKey("abstractBean");
+    }
+
+    @Test
+    public void shouldNotBindSpringBeansWithQualifiedName() {
+        // given
+        TestBean bean = prepareBean("bean");
+        TestBean qualified = prepareBean("package.bean");
+        given(applicationContext.getBeanDefinitionNames()).willReturn(new String[]{
+            bean.name(),
+            qualified.name()
+        });
+
+        // when
+        Map<String, Object> shellContext = GroovyChange.createShellContext(applicationContext, out);
+
+        // then
+        assertThat(shellContext).doesNotContainKey("abstractBean");
+    }
+
+    @Test
+    public void shouldNotBindSpringBeansUnderAlias() {
+        // given
+        TestBean bean = prepareBean("bean");
+        TestBean beanWithAlias = prepareBean("beanWithAlias");
+        given(applicationContext.getBeanDefinitionNames()).willReturn(new String[]{
+            bean.name(),
+            beanWithAlias.name()
+        });
+        given(applicationContext.getAliases(beanWithAlias.name())).willReturn(new String[] {"beanAlias" });
+
+        // when
+        Map<String, Object> shellContext = GroovyChange.createShellContext(applicationContext, out);
+
+        // then
+        assertThat(shellContext).doesNotContainKey("beanWithAlias");
+        assertThat(shellContext).containsKeys("bean", "beanAlias");
+    }
+
+    private TestBean prepareBean(String name) {
+        return prepareBean(name, false);
+    }
+
+    private TestBean prepareBean(String name, boolean isAbstract) {
+        TestBean bean = new TestBean(name);
+        given(applicationContext.getBean(bean.name())).willReturn(bean);
+        given(applicationContext.getAliases(bean.name())).willReturn(new String[0]);
+
+        GenericBeanDefinition beanDefinition = new GenericBeanDefinition();
+        beanDefinition.setAbstract(isAbstract);
+        given(applicationContext.getBeanDefinition(bean.name())).willReturn(beanDefinition);
+
+        return bean;
+    }
+
+    private static class TestBean {
+        private final String name;
+
+        public TestBean(String name) {
+            this.name = name;
+        }
+
+        String name() {
+            return name;
+        }
+
+    }
+
+}


### PR DESCRIPTION
Bind application context under `spring`.
Bind spring beans, use alias if defined.